### PR TITLE
Bugfix for when there is no kanji

### DIFF
--- a/addon/web/kanji_strokes.js
+++ b/addon/web/kanji_strokes.js
@@ -12,7 +12,10 @@ function addStrokes(html, callback) {
     
     pycmd("strokes_query:" + _document.body.innerText, strokes => {
       const characters = Object.keys(strokes);
-      if (characters.length === 0) return;
+      if (characters.length === 0) {
+        callback(html);
+        return;
+      }
 
       const regex = new RegExp(`(${characters.join("|")})`, "g");
       _document.body.innerHTML = _document.body.innerHTML.replace(


### PR DESCRIPTION
Still callback even if no kanji was found. I find this useful when I have a deck where only some of the cards have kanji.