### PR TITLE
Fix for fnmatch sometimes being case sensitive

### DIFF
--- a/addon/__init__.py
+++ b/addon/__init__.py
@@ -82,7 +82,7 @@ def is_kanji_display_context(context: Any) -> bool:
 
 def is_valid_notetype(notetype: str) -> bool:
     for n in config_note_types:
-        if fnmatch(notetype, n):
+        if fnmatch(notetype.lower(), n.lower()):
             return True
     return False
 


### PR DESCRIPTION
fnmatch.fnmatch() is case-sensitive in non-windows systems.
According to the fnmatch documentation:
"Both parameters are case-normalized using os.path.normcase()."
os.path.normcase documentation:
"Normalize the case of a pathname. On Windows, convert all characters in the pathname to lowercase, and also convert forward slashes to backward slashes. On other operating systems, return the path unchanged."